### PR TITLE
Fix CID lookup in delegated routing URI translation

### DIFF
--- a/server.go
+++ b/server.go
@@ -145,7 +145,8 @@ func (s *server) Serve() chan error {
 		close(ec)
 		return ec
 	}
-	mux.Handle("/routing/v1", delegated)
+	// Strip prefix URI since DelegatedTranslator uses a nested mux.
+	mux.Handle("/routing/v1/", http.StripPrefix("/routing/v1", delegated))
 
 	mux.Handle("/", s)
 


### PR DESCRIPTION
The HTTP delegated routing uses `GET /routing/v1/providers/{CID}` to lookup CIDs. Translate the CID lookup URI. For the translation introduced in #45 to work correctly, the URI needs to be changed to `/cid/{CID}`.

Since delegated translator instantiates its own mux, on server handler mapping the URI prefix needs to be stripped.