### PR TITLE
Count HTTP delegated routing calls by method and return 501 on `PUT`

### DIFF
--- a/metrics/server.go
+++ b/metrics/server.go
@@ -26,9 +26,10 @@ var (
 
 // Measures
 var (
-	FindLatency  = stats.Float64("indexstar/find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
-	FindBackends = stats.Float64("indexstar/find/backends", "Backends reachd in a find request", stats.UnitDimensionless)
-	FindLoad     = stats.Int64("indexstar/find/load", "Amount of calls to find", stats.UnitDimensionless)
+	FindLatency                = stats.Float64("indexstar/find/latency", "Time to respond to a find request", stats.UnitMilliseconds)
+	FindBackends               = stats.Float64("indexstar/find/backends", "Backends reached in a find request", stats.UnitDimensionless)
+	FindLoad                   = stats.Int64("indexstar/find/load", "Amount of calls to find", stats.UnitDimensionless)
+	HttpDelegatedRoutingMethod = stats.Int64("indexstar/http_delegated_routing/load", "Amount of HTTP delegated routing calls by tagged method", stats.UnitDimensionless)
 )
 
 // Views
@@ -47,6 +48,11 @@ var (
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{Method},
 	}
+	httpDelegRoutingMethodView = &view.View{
+		Measure:     HttpDelegatedRoutingMethod,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{Method},
+	}
 )
 
 // Start creates an HTTP router for serving metric info
@@ -56,6 +62,7 @@ func Start(views []*view.View) http.Handler {
 		findLatencyView,
 		findBackendView,
 		findLoadView,
+		httpDelegRoutingMethodView,
 	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)


### PR DESCRIPTION
Count the number of calls made to the HTTP delegated routing tagged by method.

Explicitly return `501 Not Implemented` on `PUT` to `/routing/v1/providers`. This is to identify that putting provider records is not currently implemented by `cid.contact`.

Relates to:
- https://github.com/ipfs/specs/pull/337#discussion_r1047399812

Fixes #54