### PR TITLE
Tighten up checks for HTTP method before handling

### DIFF
--- a/delegated_translator.go
+++ b/delegated_translator.go
@@ -42,16 +42,18 @@ func (dt *delegatedTranslator) provide(w http.ResponseWriter, r *http.Request) {
 		stats.WithTags(tag.Insert(metrics.Method, r.Method)),
 		stats.WithMeasurements(metrics.HttpDelegatedRoutingMethod.M(1)))
 
+	discardBody(r)
 	h := w.Header()
 	h.Add("Access-Control-Allow-Origin", "*")
 	h.Add("Access-Control-Allow-Methods", "GET, PUT, OPTIONS")
-	if r.Method == http.MethodOptions {
+	switch r.Method {
+	case http.MethodOptions:
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte{})
-		return
+	case http.MethodPut:
+		http.Error(w, "", http.StatusNotImplemented)
+	default:
+		http.Error(w, "", http.StatusNotFound)
 	}
-
-	http.Error(w, "", http.StatusNotImplemented)
 }
 
 func (dt *delegatedTranslator) find(w http.ResponseWriter, r *http.Request) {
@@ -70,15 +72,14 @@ func (dt *delegatedTranslator) find(w http.ResponseWriter, r *http.Request) {
 
 	h := w.Header()
 	h.Add("Access-Control-Allow-Origin", "*")
-	h.Add("Access-Control-Allow-Methods", "GET, PUT, OPTIONS")
-	if r.Method == http.MethodOptions {
+	h.Add("Access-Control-Allow-Methods", "GET, OPTIONS")
+	switch r.Method {
+	case http.MethodOptions:
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte{})
 		return
-	}
-
-	if r.Method != http.MethodGet {
-		http.Error(w, "", http.StatusNotImplemented)
+	case http.MethodGet:
+	default:
+		http.Error(w, "", http.StatusNotFound)
 		return
 	}
 

--- a/providers.go
+++ b/providers.go
@@ -14,6 +14,12 @@ import (
 )
 
 func (s *server) providers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		discardBody(r)
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
+
 	combined := make(chan []model.ProviderInfo)
 	wg := sync.WaitGroup{}
 	var err error

--- a/server.go
+++ b/server.go
@@ -114,9 +114,9 @@ func (s *server) Serve() chan error {
 	ec := make(chan error)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/cid/", s.find)
-	mux.HandleFunc("/multihash", s.find)
-	mux.HandleFunc("/multihash/", s.find)
+	mux.HandleFunc("/cid/", s.findCid)
+	mux.HandleFunc("/multihash", s.findMultihash)
+	mux.HandleFunc("/multihash/", s.findMultihashSubtree)
 	mux.HandleFunc("/providers", s.providers)
 	mux.HandleFunc("/providers/", s.provider)
 	mux.HandleFunc("/health", s.health)
@@ -189,6 +189,11 @@ func (s *server) Serve() chan error {
 }
 
 func (s *server) health(w http.ResponseWriter, r *http.Request) {
+	discardBody(r)
+	if r.Method != http.MethodGet {
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
 	httpserver.WriteJsonResponse(w, http.StatusOK, []byte("ready"))
 }
 


### PR DESCRIPTION
Only accept and forward expected HTTP methods in order to reduce exposure surface of internal services.