### PR TITLE
Start proxying metadata requests

### DIFF
--- a/server.go
+++ b/server.go
@@ -117,6 +117,7 @@ func (s *server) Serve() chan error {
 	mux.HandleFunc("/cid/", s.findCid)
 	mux.HandleFunc("/multihash", s.findMultihash)
 	mux.HandleFunc("/multihash/", s.findMultihashSubtree)
+	mux.HandleFunc("/metadata/", s.findMetadataSubtree)
 	mux.HandleFunc("/providers", s.providers)
 	mux.HandleFunc("/providers/", s.provider)
 	mux.HandleFunc("/health", s.health)


### PR DESCRIPTION
* Proxy metadata requests that are used for double hashed lookups
* The data is scattered across the same list of backends as is used for finds
* Returns the first found metadata instead of gathering across all responses

Fixes https://github.com/ipni/indexstar/issues/60