### PR TITLE
Separate max wait config for streaming response

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,8 +26,9 @@ const (
 	defaultServerMaxIdleConnsPerHost       = 100
 	defaultServerDialerTimeout             = 10 * time.Second
 	defaultServerDialerKeepAlive           = 15 * time.Second
-	defaultServerHttpClientTimeout         = 10 * time.Second
+	defaultServerHttpClientTimeout         = 30 * time.Second
 	defaultServerResultMaxWait             = 5 * time.Second
+	defaultServerResultStreamMaxWait       = 20 * time.Second
 	defaultServerMaxRequestBodySize  int64 = 8 << 10 // 8KiB
 
 	defaultCircuitHalfOpenSuccesses = 10
@@ -62,6 +63,7 @@ var config struct {
 		DialerKeepAlive     time.Duration
 		HttpClientTimeout   time.Duration
 		ResultMaxWait       time.Duration
+		ResultStreamMaxWait time.Duration
 		MaxRequestBodySize  int64
 	}
 	Circuit struct {
@@ -87,6 +89,7 @@ func init() {
 	config.Server.DialerKeepAlive = getEnvOrDefault[time.Duration]("SERVER_DIALER_KEEP_ALIVE", defaultServerDialerKeepAlive)
 	config.Server.HttpClientTimeout = getEnvOrDefault[time.Duration]("SERVER_HTTP_CLIENT_TIMEOUT", defaultServerHttpClientTimeout)
 	config.Server.ResultMaxWait = getEnvOrDefault[time.Duration]("SERVER_RESULT_MAX_WAIT", defaultServerResultMaxWait)
+	config.Server.ResultStreamMaxWait = getEnvOrDefault[time.Duration]("SERVER_RESULT_STREAM_MAX_WAIT", defaultServerResultStreamMaxWait)
 	config.Server.MaxRequestBodySize = getEnvOrDefault[int64]("SERVER_MAX_REQUEST_BODY_SIZE", defaultServerMaxRequestBodySize)
 
 	config.Circuit.HalfOpenSuccesses = getEnvOrDefault[int]("CIRCUIT_HALF_OPEN_SUCCESSES", defaultCircuitHalfOpenSuccesses)

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -58,7 +58,7 @@ func (s *server) doFindNDJson(ctx context.Context, w http.ResponseWriter, method
 	sg := &scatterGather[*url.URL, any]{
 		targets: s.servers,
 		tcb:     s.serverCallers,
-		maxWait: config.Server.ResultMaxWait,
+		maxWait: config.Server.ResultStreamMaxWait,
 	}
 
 	resultsChan := make(chan *model.ProviderResult, 1)


### PR DESCRIPTION
Separate the config for max wait when handing streaming requests with a default of 20 seconds.

Increase the default client timeout to 30 seconds, because that is the maximum the client will wait regardless of context timeout. Therefore, lower value will render result max wait time useless.