### PR TITLE
Set `Accept` header on find

### DIFF
--- a/find.go
+++ b/find.go
@@ -220,7 +220,7 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 		endpoint := *req
 		endpoint.Host = b.Host
 		endpoint.Scheme = b.Scheme
-		log := log.With("backend", endpoint)
+		log := log.With("backend", endpoint.Host)
 
 		bodyReader := bytes.NewReader(body)
 
@@ -230,6 +230,7 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 			return nil, err
 		}
 		req.Header.Set("X-Forwarded-Host", req.Host)
+		req.Header.Set("Accept", mediaTypeJson)
 		resp, err := s.Client.Do(req)
 		if err != nil {
 			log.Warnw("Failed to query backend", "err", err)

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -69,7 +69,7 @@ func (s *server) doFindNDJson(ctx context.Context, w http.ResponseWriter, method
 		endpoint := *req
 		endpoint.Host = b.Host
 		endpoint.Scheme = b.Scheme
-		log := log.With("backend", endpoint)
+		log := log.With("backend", endpoint.Host)
 
 		req, err := http.NewRequestWithContext(cctx, method, endpoint.String(), nil)
 		if err != nil {


### PR DESCRIPTION
Some incoming requests seem to be missing `Accept` header, and are rejected as bad request by `caskadht` but not storetheindex.

To avoid all of this, when finding providers in non-streaming path, set `Accept` header explicitly to JSON, because what we return to the client in this case will be JSON.