### PR TITLE
Implement non-streaming translation to reduce 404s on dht cascading

### DIFF
--- a/find.go
+++ b/find.go
@@ -193,14 +193,6 @@ func (s *server) find(w http.ResponseWriter, r *http.Request, mh multihash.Multi
 	}
 	ctx := r.Context()
 
-	if mh == nil {
-		// mh should only be nil for batch find POST request.
-		// Sanity check it and return 500 if it is.
-		log.Error("multihash must not be nil for single find requests; mh should only be nil for batch find POST request.")
-		http.Error(w, "", http.StatusInternalServerError)
-		return
-	}
-
 	// Use NDJSON response only when the request explicitly accepts it. Otherwise, fallback on
 	// JSON unless only unsupported media types are specified.
 	switch {

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -200,10 +200,12 @@ LOOP:
 		http.Error(w, "", http.StatusNotFound)
 		return
 	}
-	if err := encoder.Encode(model.FindResponse{
-		MultihashResults: []model.MultihashResult{*mhr},
-	}); err != nil {
-		log.Errorw("Failed to encode translated non streaming response", "err", err)
+	if translateNonStreaming {
+		if err := encoder.Encode(model.FindResponse{
+			MultihashResults: []model.MultihashResult{*mhr},
+		}); err != nil {
+			log.Errorw("Failed to encode translated non streaming response", "err", err)
+		}
 	}
 	latencyTags = append(latencyTags, tag.Insert(metrics.Found, "yes"))
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.7.0
 	github.com/multiformats/go-multicodec v0.7.0
+	github.com/multiformats/go-multihash v0.2.1
 	github.com/multiformats/go-varint v0.0.7
 	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.8.1
@@ -52,7 +53,6 @@ require (
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
-	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect

--- a/main.go
+++ b/main.go
@@ -44,6 +44,10 @@ func main() {
 				Name:  "translateReframe",
 				Usage: "translate reframe requests into find requests to backends",
 			},
+			&cli.BoolFlag{
+				Name:  "translateNonStreaming",
+				Usage: "Whether to translate non-streaming JSON requests to streaming NDJSON requests before scattering to backends.",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			exit := make(chan os.Signal, 1)

--- a/server.go
+++ b/server.go
@@ -22,12 +22,13 @@ type server struct {
 	context.Context
 	http.Client
 	net.Listener
-	metricsListener  net.Listener
-	cfgBase          string
-	servers          []*url.URL
-	serverCallers    []*circuitbreaker.CircuitBreaker
-	base             http.Handler
-	translateReframe bool
+	metricsListener       net.Listener
+	cfgBase               string
+	servers               []*url.URL
+	serverCallers         []*circuitbreaker.CircuitBreaker
+	base                  http.Handler
+	translateReframe      bool
+	translateNonStreaming bool
 }
 
 func NewServer(c *cli.Context) (*server, error) {
@@ -90,13 +91,14 @@ func NewServer(c *cli.Context) (*server, error) {
 			Timeout:   config.Server.HttpClientTimeout,
 			Transport: t,
 		},
-		cfgBase:          c.String("config"),
-		Listener:         bound,
-		metricsListener:  mb,
-		servers:          surls,
-		serverCallers:    scallers,
-		base:             httputil.NewSingleHostReverseProxy(surls[0]),
-		translateReframe: c.Bool("translateReframe"),
+		cfgBase:               c.String("config"),
+		Listener:              bound,
+		metricsListener:       mb,
+		servers:               surls,
+		serverCallers:         scallers,
+		base:                  httputil.NewSingleHostReverseProxy(surls[0]),
+		translateReframe:      c.Bool("translateReframe"),
+		translateNonStreaming: c.Bool("translateNonStreaming"),
 	}, nil
 }
 


### PR DESCRIPTION
DHT lookups take longer to complete in comparison with IPNI search. This is why streaming response was introduced such that results are returned as soon as they are found instead of having to wait for all results before returning any.

Internally, indexstar uses a circuit breaker mechanism that would exclude slow backends from the search space. The max wait for non-streaming requests is set to 5 seconds. When a client uses non-streaming `Accept` header with DHT lookup cascade enabled, there is a high chance that the response would take longer than the internal timeout of 5 seconds, which results in the DHT cascade endpoints to eventually be excluded from the search space.

To avoid this, the changes here introduce an option to always translate non-streaming requests to streaming ndjson, and aggregate the result in a batch response to the client with internal timeout of 5 seconds. This would avoid the slow DHT lookups to open the circuit and ultimately reduce the chances of 404 for the clients that use non-streaming `Accept` header with dht cascade enabled.