### PR TITLE
Make backend CB individually configurable and separate cascade

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/mercari/go-circuitbreaker"
+)
+
+var Matchers struct {
+	Any        HttpRequestMatcher
+	AnyOf      func(...HttpRequestMatcher) HttpRequestMatcher
+	QueryParam func(key, value string) HttpRequestMatcher
+}
+
+type (
+	HttpRequestMatcher func(r *http.Request) bool
+	Backend            interface {
+		URL() *url.URL
+		CB() *circuitbreaker.CircuitBreaker
+		Matches(r *http.Request) bool
+	}
+	SimpleBackend struct {
+		url     *url.URL
+		cb      *circuitbreaker.CircuitBreaker
+		matcher HttpRequestMatcher
+	}
+)
+
+func (b *SimpleBackend) URL() *url.URL {
+	return b.url
+}
+
+func (b *SimpleBackend) CB() *circuitbreaker.CircuitBreaker {
+	return b.cb
+}
+
+func init() {
+	Matchers.Any = func(*http.Request) bool { return true }
+	Matchers.AnyOf = func(ms ...HttpRequestMatcher) HttpRequestMatcher {
+		return func(r *http.Request) bool {
+			for _, m := range ms {
+				if m(r) {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	Matchers.QueryParam = func(key, value string) HttpRequestMatcher {
+		return func(r *http.Request) bool {
+			if r == nil {
+				return false
+			}
+			values, ok := r.URL.Query()[key]
+			if !ok {
+				return false
+			}
+			for _, got := range values {
+				if value == got {
+					return true
+				}
+			}
+			return false
+		}
+	}
+}
+
+func NewBackend(u string, cb *circuitbreaker.CircuitBreaker, matcher HttpRequestMatcher) (Backend, error) {
+	burl, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SimpleBackend{
+		url:     burl,
+		cb:      cb,
+		matcher: matcher,
+	}, nil
+}
+
+func (b *SimpleBackend) Matches(r *http.Request) bool {
+	return b.matcher(r)
+}

--- a/main.go
+++ b/main.go
@@ -23,23 +23,27 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:      "config",
-				Usage:     "config file",
+				Usage:     "Path to config file",
 				TakesFile: true,
 			},
 			&cli.StringFlag{
 				Name:  "listen",
-				Usage: "listen address",
+				Usage: "HTTP server Listen address",
 				Value: ":8080",
 			},
 			&cli.StringFlag{
 				Name:  "metrics",
-				Usage: "metrics address",
+				Usage: "Metrics server listen address",
 				Value: ":8081",
 			},
 			&cli.StringSliceFlag{
 				Name:  "backends",
-				Usage: "backends to use",
+				Usage: "Backends to propagate requests to.",
 				Value: cli.NewStringSlice("https://cid.contact/"),
+			},
+			&cli.StringSliceFlag{
+				Name:  "cascadeBackends",
+				Usage: "Backends to propagate lookup with SERVER_CASCADE_LABELS env var as query parameter",
 			},
 			&cli.BoolFlag{
 				Name:  "translateReframe",
@@ -104,7 +108,7 @@ func main() {
 				case err := <-done:
 					return err
 				case <-reloadSig:
-					err := s.Reload()
+					err := s.Reload(c)
 					if err != nil {
 						log.Warnf("couldn't reload servers: %s", err)
 					}

--- a/providers.go
+++ b/providers.go
@@ -30,7 +30,7 @@ func (s *server) providers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, server := range s.servers {
+	for _, backend := range s.backends {
 		wg.Add(1)
 		go func(server *url.URL) {
 			defer wg.Done()
@@ -72,7 +72,7 @@ func (s *server) providers(w http.ResponseWriter, r *http.Request) {
 			default:
 				log.Warn("unexpected response while getting providers")
 			}
-		}(server)
+		}(backend.URL())
 	}
 	go func() {
 		wg.Wait()
@@ -122,7 +122,7 @@ func (s *server) provider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, server := range s.servers {
+	for _, backend := range s.backends {
 		wg.Add(1)
 		go func(server *url.URL) {
 			defer wg.Done()
@@ -162,7 +162,7 @@ func (s *server) provider(w http.ResponseWriter, r *http.Request) {
 			default:
 				log.Warn("unexpected response while getting provider")
 			}
-		}(server)
+		}(backend.URL())
 	}
 	go func() {
 		wg.Wait()

--- a/scatter_gather_test.go
+++ b/scatter_gather_test.go
@@ -4,20 +4,39 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/mercari/go-circuitbreaker"
 	"github.com/stretchr/testify/require"
 )
 
+var _ (Backend) = (*testBackend)(nil)
+
+type testBackend int
+
+func (t testBackend) URL() *url.URL {
+	u, err := url.Parse("http://test.invalid")
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func (t testBackend) CB() *circuitbreaker.CircuitBreaker { return nil }
+
+func (t testBackend) Matches(*http.Request) bool { return false }
+
 func TestScatterGather_GathersExpectedResults(t *testing.T) {
-	subject := scatterGather[int, string]{
-		targets: []int{1, 2, 3, 4, 5},
-		maxWait: 2 * time.Second,
+	subject := scatterGather[testBackend, string]{
+		backends: []testBackend{testBackend(1), testBackend(2), testBackend(3), testBackend(4), testBackend(5)},
+		maxWait:  2 * time.Second,
 	}
 
 	ctx := context.Background()
-	err := subject.scatter(ctx, func(cctx context.Context, i int) (*string, error) {
+	err := subject.scatter(ctx, func(cctx context.Context, i testBackend) (*string, error) {
 		if cctx.Err() == nil {
 			str := fmt.Sprintf("%d fish", i)
 			return &str, nil
@@ -39,12 +58,12 @@ func TestScatterGather_GathersExpectedResults(t *testing.T) {
 }
 
 func TestScatterGather_ExcludesScatterErrors(t *testing.T) {
-	subject := scatterGather[int, string]{
-		targets: []int{1, 2, 3},
-		maxWait: 2 * time.Second,
+	subject := scatterGather[testBackend, string]{
+		backends: []testBackend{testBackend(1), testBackend(2), testBackend(3)},
+		maxWait:  2 * time.Second,
 	}
 	ctx := context.Background()
-	err := subject.scatter(ctx, func(cctx context.Context, i int) (*string, error) {
+	err := subject.scatter(ctx, func(cctx context.Context, i testBackend) (*string, error) {
 		if i == 2 {
 			return nil, errors.New("fish says no")
 		}
@@ -67,12 +86,12 @@ func TestScatterGather_ExcludesScatterErrors(t *testing.T) {
 }
 
 func TestScatterGather_DoesNotWaitLongerThanExpected(t *testing.T) {
-	subject := scatterGather[int, string]{
-		targets: []int{1},
-		maxWait: 100 * time.Millisecond,
+	subject := scatterGather[testBackend, string]{
+		backends: []testBackend{testBackend(1)},
+		maxWait:  100 * time.Millisecond,
 	}
 	ctx := context.Background()
-	err := subject.scatter(ctx, func(cctx context.Context, i int) (*string, error) {
+	err := subject.scatter(ctx, func(cctx context.Context, i testBackend) (*string, error) {
 		time.Sleep(2 * time.Second)
 		if cctx.Err() == nil {
 			str := fmt.Sprintf("%d fish", i)
@@ -90,14 +109,14 @@ func TestScatterGather_DoesNotWaitLongerThanExpected(t *testing.T) {
 }
 
 func TestScatterGather_GathersNothingWhenContextIsCancelled(t *testing.T) {
-	subject := scatterGather[int, string]{
-		targets: []int{1, 2, 3},
-		maxWait: 2 * time.Second,
+	subject := scatterGather[testBackend, string]{
+		backends: []testBackend{testBackend(1), testBackend(2), testBackend(3)},
+		maxWait:  2 * time.Second,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	cancel()
 
-	err := subject.scatter(ctx, func(cctx context.Context, i int) (*string, error) {
+	err := subject.scatter(ctx, func(cctx context.Context, i testBackend) (*string, error) {
 		if cctx.Err() == nil {
 			str := fmt.Sprintf("%d fish", i)
 			return &str, nil


### PR DESCRIPTION
Refactor backend instantiation such that circuit breaker backends are individually configurable. Reflect changes across the repo.

Add the ability to check if a backend matches a request before attempting to call it. This avoids response slow-down caused by slow backends early in the chain

Introduce a separate configuration to mark cascade lookup backends with explicit matcher in order to avoid routing all requests to them.

Relates to:
 - https://github.com/ipni/indexstar/issues/86