### PR TITLE
Add a metric to track backend type

### DIFF
--- a/find.go
+++ b/find.go
@@ -233,7 +233,13 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 			stats.WithMeasurements(metrics.FindLoad.M(1)))
 	}()
 
-	sg := &scatterGather[Backend, *model.FindResponse]{
+	// sgResponse is a struct that exists to capture the backend that the response has been received from
+	type sgResponse struct {
+		r *model.FindResponse
+		b Backend
+	}
+
+	sg := &scatterGather[Backend, sgResponse]{
 		backends: s.backends,
 		maxWait:  config.Server.ResultMaxWait,
 	}
@@ -242,7 +248,7 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 	defer cancel()
 
 	var count int32
-	if err := sg.scatter(ctx, func(cctx context.Context, b Backend) (**model.FindResponse, error) {
+	if err := sg.scatter(ctx, func(cctx context.Context, b Backend) (*sgResponse, error) {
 		// Copy the URL from original request and override host/schema to point
 		// to the server.
 		endpoint := *req
@@ -282,7 +288,7 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 			if err != nil {
 				return nil, circuitbreaker.MarkAsSuccess(err)
 			}
-			return &providers, nil
+			return &sgResponse{b: b, r: providers}, nil
 		case http.StatusNotFound:
 			atomic.AddInt32(&count, 1)
 			return nil, nil
@@ -304,37 +310,46 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 	// TODO: stream out partial response as they come in.
 	var resp model.FindResponse
 	var rs resultStats
+	var foundRegular, foundCaskade bool
 outer:
-	for prov := range sg.gather(ctx) {
-		if len(prov.MultihashResults) > 0 {
+	for r := range sg.gather(ctx) {
+		if len(r.r.MultihashResults) > 0 {
 			if resp.MultihashResults == nil {
-				resp.MultihashResults = prov.MultihashResults
+				resp.MultihashResults = r.r.MultihashResults
 			} else {
-				if !bytes.Equal(resp.MultihashResults[0].Multihash, prov.MultihashResults[0].Multihash) {
+				if !bytes.Equal(resp.MultihashResults[0].Multihash, r.r.MultihashResults[0].Multihash) {
 					// weird / invalid.
-					log.Warnw("conflicting results", "q", req, "first", resp.MultihashResults[0].Multihash, "second", prov.MultihashResults[0].Multihash)
+					log.Warnw("conflicting results", "q", req, "first", resp.MultihashResults[0].Multihash, "second", r.r.MultihashResults[0].Multihash)
 					return http.StatusInternalServerError, nil
 				}
-				for _, pr := range prov.MultihashResults[0].ProviderResults {
+				for _, pr := range r.r.MultihashResults[0].ProviderResults {
 					for _, rr := range resp.MultihashResults[0].ProviderResults {
 						if bytes.Equal(rr.ContextID, pr.ContextID) && bytes.Equal([]byte(rr.Provider.ID), []byte(pr.Provider.ID)) {
 							continue outer
 						}
 					}
+					_, isCaskade := r.b.(caskadeBackend)
+					foundCaskade = foundCaskade || isCaskade
+					foundRegular = foundRegular || !isCaskade
+
 					resp.MultihashResults[0].ProviderResults = append(resp.MultihashResults[0].ProviderResults, pr)
 				}
 			}
 		}
 
-		if len(prov.EncryptedMultihashResults) > 0 {
+		if len(r.r.EncryptedMultihashResults) > 0 {
 			if resp.EncryptedMultihashResults == nil {
-				resp.EncryptedMultihashResults = prov.EncryptedMultihashResults
+				resp.EncryptedMultihashResults = r.r.EncryptedMultihashResults
 			} else {
-				if !bytes.Equal(resp.EncryptedMultihashResults[0].Multihash, prov.EncryptedMultihashResults[0].Multihash) {
-					log.Warnw("conflicting encrypted results", "q", req, "first", resp.EncryptedMultihashResults[0].Multihash, "second", prov.EncryptedMultihashResults[0].Multihash)
+				if !bytes.Equal(resp.EncryptedMultihashResults[0].Multihash, r.r.EncryptedMultihashResults[0].Multihash) {
+					log.Warnw("conflicting encrypted results", "q", req, "first", resp.EncryptedMultihashResults[0].Multihash, "second", r.r.EncryptedMultihashResults[0].Multihash)
 					return http.StatusInternalServerError, nil
 				}
-				resp.EncryptedMultihashResults[0].EncryptedValueKeys = append(resp.EncryptedMultihashResults[0].EncryptedValueKeys, prov.EncryptedMultihashResults[0].EncryptedValueKeys...)
+				_, isCaskade := r.b.(caskadeBackend)
+				foundCaskade = foundCaskade || isCaskade
+				foundRegular = foundRegular || !isCaskade
+
+				resp.EncryptedMultihashResults[0].EncryptedValueKeys = append(resp.EncryptedMultihashResults[0].EncryptedValueKeys, r.r.EncryptedMultihashResults[0].EncryptedValueKeys...)
 			}
 		}
 	}
@@ -347,6 +362,16 @@ outer:
 		return http.StatusNotFound, nil
 	} else {
 		latencyTags = append(latencyTags, tag.Insert(metrics.Found, "yes"))
+		if foundCaskade {
+			latencyTags = append(latencyTags, tag.Insert(metrics.FoundCaskade, "yes"))
+		} else {
+			latencyTags = append(latencyTags, tag.Insert(metrics.FoundCaskade, "no"))
+		}
+		if foundRegular {
+			latencyTags = append(latencyTags, tag.Insert(metrics.FoundRegular, "yes"))
+		} else {
+			latencyTags = append(latencyTags, tag.Insert(metrics.FoundRegular, "no"))
+		}
 	}
 
 	rs.observeFindResponse(&resp)

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -18,11 +18,13 @@ var log = logging.Logger("indexstar/metrics")
 
 // Global Tags
 var (
-	ErrKind, _   = tag.NewKey("errKind")
-	Method, _    = tag.NewKey("method")
-	Found, _     = tag.NewKey("found")
-	Version, _   = tag.NewKey("version")
-	Transport, _ = tag.NewKey("transport")
+	ErrKind, _      = tag.NewKey("errKind")
+	Method, _       = tag.NewKey("method")
+	Found, _        = tag.NewKey("found")
+	FoundCaskade, _ = tag.NewKey("foundCaskade")
+	FoundRegular, _ = tag.NewKey("foundRegular")
+	Version, _      = tag.NewKey("version")
+	Transport, _    = tag.NewKey("transport")
 )
 
 // Measures
@@ -39,7 +41,7 @@ var (
 	findLatencyView = &view.View{
 		Measure:     FindLatency,
 		Aggregation: view.Distribution(0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000),
-		TagKeys:     []tag.Key{Method, Found},
+		TagKeys:     []tag.Key{Method, Found, FoundCaskade, FoundRegular},
 	}
 	findBackendView = &view.View{
 		Measure:     FindBackends,

--- a/server.go
+++ b/server.go
@@ -29,6 +29,11 @@ type server struct {
 	translateNonStreaming bool
 }
 
+// caskadeBackend is a marker for caskade backends
+type caskadeBackend struct {
+	Backend
+}
+
 func NewServer(c *cli.Context) (*server, error) {
 	bound, err := net.Listen("tcp", c.String("listen"))
 	if err != nil {
@@ -124,7 +129,7 @@ func loadBackends(servers, cascadeServers []string) ([]Backend, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to instantiate cascade backend: %w", err)
 		}
-		backends = append(backends, b)
+		backends = append(backends, caskadeBackend{Backend: b})
 	}
 
 	if len(backends) == 0 {


### PR DESCRIPTION
Add tag foundCaskade and foundRegular into FindLatency metric that aims to help to understand what backends contributed to the output