### PR TITLE
Allow batch find when --translateNonStreaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+*~
+indexstar

--- a/find.go
+++ b/find.go
@@ -189,6 +189,13 @@ func (s *server) find(w http.ResponseWriter, r *http.Request, mh multihash.Multi
 			http.Error(w, "", http.StatusBadRequest)
 			return
 		}
+		rcode, resp := s.doFind(r.Context(), r.Method, findMethodOrig, r.URL, rb)
+		if rcode != http.StatusOK {
+			http.Error(w, "", rcode)
+			return
+		}
+		httpserver.WriteJsonResponse(w, http.StatusOK, resp)
+		return
 	default:
 		discardBody(r)
 		http.Error(w, "", http.StatusNotFound)


### PR DESCRIPTION
Handle batch find, that uses a POST request, the same whether or not --translateNonStreaming is specified.

Fixes #94