### PR TITLE
Lower the log level for context timeouts

### DIFF
--- a/find.go
+++ b/find.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -282,8 +283,13 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 		}
 		defer resp.Body.Close()
 		data, err := io.ReadAll(resp.Body)
+
 		if err != nil {
-			log.Warnw("Failed to read backend response", "err", err)
+			if errors.Is(err, context.Canceled) {
+				log.Info("Failed to read backend response because of cancelled context")
+			} else {
+				log.Warnw("Failed to read backend response", "err", err)
+			}
 			return nil, err
 		}
 

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -242,7 +243,12 @@ func (s *server) doFindNDJson(ctx context.Context, w http.ResponseWriter, source
 					continue
 				}
 				if err := scanner.Err(); err != nil {
-					log.Warnw("Failed to read backend response", "err", err)
+					if errors.Is(err, context.Canceled) {
+						log.Info("Failed to read backend response because of cancelled context")
+					} else {
+						log.Warnw("Failed to read backend response", "err", err)
+					}
+
 					return nil, circuitbreaker.MarkAsSuccess(err)
 				}
 				return nil, nil


### PR DESCRIPTION
Timeouts is a part of normal flow especially for caskade backends and hence shouldn't be logged as warnings or errors.