### PR TITLE
Add providers and dh backends

### DIFF
--- a/delegated_translator.go
+++ b/delegated_translator.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/ipfs/go-cid"
 	"github.com/ipni/go-libipni/find/model"
 	"github.com/ipni/indexstar/metrics"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -96,7 +97,14 @@ func (dt *delegatedTranslator) find(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}
-	rcode, resp := dt.be(r.Context(), http.MethodGet, findMethodDelegated, uri, []byte{})
+
+	c, err := cid.Decode(cidUrlParam)
+	if err != nil {
+		http.Error(w, "", http.StatusBadRequest)
+		return
+	}
+
+	rcode, resp := dt.be(r.Context(), http.MethodGet, findMethodDelegated, uri, []byte{}, c.Hash())
 
 	if rcode != http.StatusOK {
 		http.Error(w, "", rcode)

--- a/find.go
+++ b/find.go
@@ -269,8 +269,10 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 	if err := sg.scatter(ctx, func(cctx context.Context, b Backend) (*sgResponse, error) {
 		// forward double hashed requests to double hashed backends only and regular requests to regular backends
 		_, isDhBackend := b.(dhBackend)
+		_, isProvidersBackend := b.(providersBackend)
 		if (dmh.Code == multihash.DBL_SHA2_256 && !isDhBackend) ||
-			(dmh.Code != multihash.DBL_SHA2_256 && isDhBackend) {
+			(dmh.Code != multihash.DBL_SHA2_256 && isDhBackend) ||
+			isProvidersBackend {
 			return nil, nil
 		}
 

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -178,8 +178,10 @@ func (s *server) doFindNDJson(ctx context.Context, w http.ResponseWriter, source
 	if err := sg.scatter(ctx, func(cctx context.Context, b Backend) (*any, error) {
 		// forward double hashed requests to double hashed backends only and regular requests to regular backends
 		_, isDhBackend := b.(dhBackend)
+		_, isProvidersBackend := b.(providersBackend)
 		if (dmh.Code == multihash.DBL_SHA2_256 && !isDhBackend) ||
-			(dmh.Code != multihash.DBL_SHA2_256 && isDhBackend) {
+			(dmh.Code != multihash.DBL_SHA2_256 && isDhBackend) ||
+			isProvidersBackend {
 			return nil, nil
 		}
 

--- a/providers.go
+++ b/providers.go
@@ -30,6 +30,10 @@ func (s *server) providers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, backend := range s.backends {
+		// do not send providers requests to not providers backends
+		if _, ok := backend.(providersBackend); !ok {
+			continue
+		}
 		wg.Add(1)
 		go func(server *url.URL) {
 			defer wg.Done()
@@ -122,6 +126,10 @@ func (s *server) provider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, backend := range s.backends {
+		// do not send providers requests to not providers backends
+		if _, ok := backend.(providersBackend); !ok {
+			continue
+		}
 		wg.Add(1)
 		go func(server *url.URL) {
 			defer wg.Done()

--- a/reframe_translate_test.go
+++ b/reframe_translate_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func doServe(ctx context.Context, bound net.Listener) {
-	backends, err := loadBackends([]string{"https://cid.contact/"}, nil)
+	backends, err := loadBackends([]string{"https://cid.contact/"}, nil, nil, nil)
 	if err != nil {
 		return
 	}

--- a/reframe_translator.go
+++ b/reframe_translator.go
@@ -15,10 +15,11 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
 	"github.com/multiformats/go-varint"
 )
 
-type findFunc func(ctx context.Context, method, source string, req *url.URL, body []byte) (int, []byte)
+type findFunc func(ctx context.Context, method, source string, req *url.URL, body []byte, mh multihash.Multihash) (int, []byte)
 
 func NewReframeTranslatorHTTPHandler(backend findFunc) (http.HandlerFunc, error) {
 	svc, err := NewReframeTranslatorService(backend)
@@ -47,7 +48,7 @@ func (x *ReframeTranslatorService) FindProviders(ctx context.Context, key cid.Ci
 	go func() {
 		defer close(out)
 
-		respStatus, respJSON := x.findBackend(ctx, "GET", findMethodReframe, req, []byte{})
+		respStatus, respJSON := x.findBackend(ctx, "GET", findMethodReframe, req, []byte{}, key.Hash())
 		if respStatus == http.StatusNotFound {
 			// no responses.
 			return


### PR DESCRIPTION
Add special backend types for handling providers and double hashed requests. We need to start having specialisation as the number of different backends grows and scatter gather across everything becomes inefficient.

Fixes https://github.com/ipni/storetheindex/issues/1913