### PR TITLE
Include metadata when checking for result uniqueness

### DIFF
--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -54,6 +54,7 @@ func (r resultSet) putIfAbsent(p *encryptedOrPlainResult) bool {
 		v = make([]byte, 0, len(pidb)+len(p.ContextID))
 		v = append(v, pidb...)
 		v = append(v, p.ContextID...)
+		v = append(v, p.Metadata...)
 	}
 	key := crc32.ChecksumIEEE(v)
 	if _, seen := r[key]; seen {


### PR DESCRIPTION
It seems that extended providers add metadata to the same context ID. When checking for duplicate results include metadata so that results with extra metadata are not excluded.