### PR TITLE
Remove fallback and base routing

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,10 +53,6 @@ func main() {
 				Name:  providersBackendsArg,
 				Usage: "Backends to propagate providers requests to.",
 			},
-			&cli.StringFlag{
-				Name:  "fallbackBackend",
-				Usage: "Fallback Backend is used for requests to the index page",
-			},
 			&cli.BoolFlag{
 				Name:  "translateNonStreaming",
 				Usage: "Whether to translate non-streaming JSON requests to streaming NDJSON requests before scattering to backends.",


### PR DESCRIPTION
`indexstar` now embeds the cid.contact landing page. As a result there is no need to reverse proxy the root to a backend nor fallback mechanism for it.