### PR TITLE
Use go-libipni pcache package to retrieve and cache provider info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/index-provider v0.9.1
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipni/go-libipni v0.2.6
+	github.com/ipni/go-libipni v0.2.9-0.20230710084357-c0148e9510c3
 	github.com/libp2p/go-libp2p v0.28.1
 	github.com/mercari/go-circuitbreaker v0.0.2
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/index-provider v0.9.1
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipni/go-libipni v0.2.9-0.20230710084357-c0148e9510c3
+	github.com/ipni/go-libipni v0.2.9
 	github.com/libp2p/go-libp2p v0.28.1
 	github.com/mercari/go-circuitbreaker v0.0.2
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/ipld/go-car/v2 v2.6.0/go.mod h1:qoqfgPnQYcaAYcfphctffdaNWJIWBR2QN4pju
 github.com/ipld/go-codec-dagpb v1.5.0 h1:RspDRdsJpLfgCI0ONhTAnbHdySGD4t+LHSPK4X1+R0k=
 github.com/ipld/go-ipld-prime v0.20.0 h1:Ud3VwE9ClxpO2LkCYP7vWPc0Fo+dYdYzgxUJZ3uRG4g=
 github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawdGVlJDE8kK+M=
-github.com/ipni/go-libipni v0.2.9-0.20230710084357-c0148e9510c3 h1:eWJSiUUMbMlx9HWrnOttTOBfyyOcQ5WM50JV9b6e4nw=
-github.com/ipni/go-libipni v0.2.9-0.20230710084357-c0148e9510c3/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
+github.com/ipni/go-libipni v0.2.9 h1:r0R+sZYs6I5qPSuc8JOk5b12gb3a59RR5JaRuM1kv5E=
+github.com/ipni/go-libipni v0.2.9/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/ipld/go-car/v2 v2.6.0/go.mod h1:qoqfgPnQYcaAYcfphctffdaNWJIWBR2QN4pju
 github.com/ipld/go-codec-dagpb v1.5.0 h1:RspDRdsJpLfgCI0ONhTAnbHdySGD4t+LHSPK4X1+R0k=
 github.com/ipld/go-ipld-prime v0.20.0 h1:Ud3VwE9ClxpO2LkCYP7vWPc0Fo+dYdYzgxUJZ3uRG4g=
 github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawdGVlJDE8kK+M=
-github.com/ipni/go-libipni v0.2.6 h1:YKjdNs0dlLvGkNyNAA8gvzZifAQCaclktlG5kSfBims=
-github.com/ipni/go-libipni v0.2.6/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
+github.com/ipni/go-libipni v0.2.9-0.20230710084357-c0148e9510c3 h1:eWJSiUUMbMlx9HWrnOttTOBfyyOcQ5WM50JV9b6e4nw=
+github.com/ipni/go-libipni v0.2.9-0.20230710084357-c0148e9510c3/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=


### PR DESCRIPTION
Periodically gets provider information from all sources to provide. Provides a unified view of all provider information, with high-performance concurrent reads.