### PR TITLE
Use "peer" schema for unknown providers at /routing/v1/providers

### DIFF
--- a/delegated_translator.go
+++ b/delegated_translator.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	peerSchema      = "peer"
 	unknownProtocol = "unknown"
 	unknownSchema   = unknownProtocol
 )
@@ -157,10 +158,9 @@ func (dt *delegatedTranslator) find(w http.ResponseWriter, r *http.Request) {
 		err := md.UnmarshalBinary(p.Metadata)
 		if err != nil {
 			appendIfUnique(&drProvider{
-				Protocol: unknownProtocol,
-				Schema:   unknownSchema,
-				ID:       p.Provider.ID,
-				Addrs:    p.Provider.Addrs,
+				Schema: peerSchema,
+				ID:     p.Provider.ID,
+				Addrs:  p.Provider.Addrs,
 			})
 		} else {
 			for _, proto := range md.Protocols() {


### PR DESCRIPTION
The /routing/v1/providers/ endpoint now reports unknown schema as "peer", and omits the Protocol.

Testing was manual testing using example in issue.

Fixes #147