### PR TITLE
New version

### DIFF
--- a/find.go
+++ b/find.go
@@ -40,6 +40,7 @@ func (s *server) findCid(w http.ResponseWriter, r *http.Request, encrypted bool)
 		s.find(w, r, c.Hash(), encrypted)
 	default:
 		w.Header().Set("Allow", http.MethodGet)
+		w.Header().Add("Allow", http.MethodOptions)
 		http.Error(w, "", http.StatusMethodNotAllowed)
 	}
 }
@@ -57,6 +58,7 @@ func (s *server) findMultihashSubtree(w http.ResponseWriter, r *http.Request, en
 		s.find(w, r, mh, encrypted)
 	default:
 		w.Header().Set("Allow", http.MethodGet)
+		w.Header().Add("Allow", http.MethodOptions)
 		http.Error(w, "", http.StatusMethodNotAllowed)
 	}
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.0.7"
+  "version": "v0.1.0"
 }


### PR DESCRIPTION
Update to version v0.1.0 since there are API changes:
- Support sepraate encrypted and non-encrypted lookup paths
- Removed support for HTTP POST /multihash
- Return status 405 "method not allowed" where appropriate