### PR TITLE
Fix delegated find path

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -10,7 +10,6 @@ on:
       - 'docs/**'
     branches:
       - main
-      - experiment-log-notfound
 
 jobs:
   publisher:

--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -10,8 +10,8 @@ on:
       - 'docs/**'
     branches:
       - main
-      # See https://github.com/ipni/indexstar/pull/105
-      - ivan/add-sharding-key
+      - experiment-log-notfound
+
 jobs:
   publisher:
     if: ${{ github.event.pusher.name != 'sti-bot' }}

--- a/delegated_translator.go
+++ b/delegated_translator.go
@@ -82,7 +82,7 @@ func (dt *delegatedTranslator) find(w http.ResponseWriter, r *http.Request, encr
 	cidUrlParam := path.Base(r.URL.Path)
 
 	// Translate URL by mapping `/providers/{CID}` to `/cid/{CID}`.
-	uri := r.URL.JoinPath("../cid", cidUrlParam)
+	uri := r.URL.JoinPath("../../cid", cidUrlParam)
 	rcode, resp := dt.be(r.Context(), http.MethodGet, findMethodDelegated, uri, encrypted)
 	if rcode != http.StatusOK {
 		http.Error(w, "", rcode)

--- a/delegated_translator.go
+++ b/delegated_translator.go
@@ -46,14 +46,16 @@ func (dt *delegatedTranslator) provide(w http.ResponseWriter, r *http.Request) {
 
 	h := w.Header()
 	h.Add("Access-Control-Allow-Origin", "*")
-	h.Add("Access-Control-Allow-Methods", "GET, PUT, OPTIONS")
+	h.Add("Access-Control-Allow-Methods", "GET, OPTIONS")
 	switch r.Method {
 	case http.MethodOptions:
 		w.WriteHeader(http.StatusOK)
 	case http.MethodPut:
 		http.Error(w, "", http.StatusNotImplemented)
 	default:
-		http.Error(w, "", http.StatusNotFound)
+		h.Add("Allow", http.MethodGet)
+		h.Add("Allow", http.MethodOptions)
+		http.Error(w, "", http.StatusMethodNotAllowed)
 	}
 }
 

--- a/find.go
+++ b/find.go
@@ -138,16 +138,19 @@ func (s *server) findMetadataSubtree(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for md := range sg.gather(ctx) {
-		// It's ok to return the first encountered metadata. This is because metadata is uniquely identified
-		// by ValueKey (peerID + contextID). I.e. it's not possible to have different metadata records for the same ValueKey.
-		// In comparison to regular find requests where it's perfectly normal to have different results returned by different IPNI
-		// instances and hence they need to be aggregated.
+		// It is ok to return the first encountered metadata. This is because
+		// metadata is uniquely identified by ValueKey (peerID + contextID).
+		// I.e. it is not possible to have different metadata records for the
+		// same ValueKey.
+		//
+		// Whereas in regular find requests it is perfectly normal to have
+		// different results returned by different IPNI instances and hence
+		// they need to be aggregated.
 		if len(md) > 0 {
 			writeJsonResponse(w, http.StatusOK, md)
 			return
 		}
 	}
-	log.Infow("X404 no metadata results found by sg", "url", reqURL.String())
 	http.Error(w, "", http.StatusNotFound)
 }
 
@@ -333,7 +336,6 @@ outer:
 		stats.WithMeasurements(metrics.FindBackends.M(float64(atomic.LoadInt32(&count)))))
 
 	if len(resp.MultihashResults) == 0 && len(resp.EncryptedMultihashResults) == 0 {
-		log.Infow("X404 no multihash results found by sg", "url", reqURL.String())
 		latencyTags = append(latencyTags, tag.Insert(metrics.Found, "no"))
 		return http.StatusNotFound, nil
 	}

--- a/find.go
+++ b/find.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -32,7 +31,7 @@ func (s *server) findCid(w http.ResponseWriter, r *http.Request, encrypted bool)
 	case http.MethodOptions:
 		handleIPNIOptions(w, false)
 	case http.MethodGet:
-		sc := strings.TrimPrefix(path.Base(r.URL.Path), "cid/")
+		sc := path.Base(r.URL.Path)
 		c, err := cid.Decode(sc)
 		if err != nil {
 			http.Error(w, "invalid cid: "+err.Error(), http.StatusBadRequest)
@@ -148,6 +147,7 @@ func (s *server) findMetadataSubtree(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	log.Infow("X404 no metadata results found by sg", "url", reqURL.String())
 	http.Error(w, "", http.StatusNotFound)
 }
 
@@ -182,7 +182,7 @@ func (s *server) find(w http.ResponseWriter, r *http.Request, mh multihash.Multi
 	}
 }
 
-func (s *server) doFind(ctx context.Context, method, source string, req *url.URL, encrypted bool) (int, []byte) {
+func (s *server) doFind(ctx context.Context, method, source string, reqURL *url.URL, encrypted bool) (int, []byte) {
 	start := time.Now()
 	latencyTags := []tag.Mutator{tag.Insert(metrics.Method, method)}
 	loadTags := []tag.Mutator{tag.Insert(metrics.Method, source)}
@@ -220,7 +220,7 @@ func (s *server) doFind(ctx context.Context, method, source string, req *url.URL
 
 		// Copy the URL from original request and override host/schema to point
 		// to the server.
-		endpoint := *req
+		endpoint := *reqURL
 		endpoint.Host = b.URL().Host
 		endpoint.Scheme = b.URL().Scheme
 		log := log.With("backend", endpoint.Host)
@@ -299,7 +299,7 @@ outer:
 			} else {
 				if !bytes.Equal(resp.MultihashResults[0].Multihash, r.rsp.MultihashResults[0].Multihash) {
 					// weird / invalid.
-					log.Warnw("conflicting results", "q", req, "first", resp.MultihashResults[0].Multihash, "second", r.rsp.MultihashResults[0].Multihash)
+					log.Warnw("conflicting results", "q", reqURL, "first", resp.MultihashResults[0].Multihash, "second", r.rsp.MultihashResults[0].Multihash)
 					return http.StatusInternalServerError, nil
 				}
 				for _, pr := range r.rsp.MultihashResults[0].ProviderResults {
@@ -320,7 +320,7 @@ outer:
 				updateFoundFlags(r.bknd)
 			} else {
 				if !bytes.Equal(resp.EncryptedMultihashResults[0].Multihash, r.rsp.EncryptedMultihashResults[0].Multihash) {
-					log.Warnw("conflicting encrypted results", "q", req, "first", resp.EncryptedMultihashResults[0].Multihash, "second", r.rsp.EncryptedMultihashResults[0].Multihash)
+					log.Warnw("conflicting encrypted results", "q", reqURL, "first", resp.EncryptedMultihashResults[0].Multihash, "second", r.rsp.EncryptedMultihashResults[0].Multihash)
 					return http.StatusInternalServerError, nil
 				}
 				updateFoundFlags(r.bknd)
@@ -333,20 +333,21 @@ outer:
 		stats.WithMeasurements(metrics.FindBackends.M(float64(atomic.LoadInt32(&count)))))
 
 	if len(resp.MultihashResults) == 0 && len(resp.EncryptedMultihashResults) == 0 {
+		log.Infow("X404 no multihash results found by sg", "url", reqURL.String())
 		latencyTags = append(latencyTags, tag.Insert(metrics.Found, "no"))
 		return http.StatusNotFound, nil
-	} else {
-		latencyTags = append(latencyTags, tag.Insert(metrics.Found, "yes"))
-		yesno := func(yn bool) string {
-			if yn {
-				return "yes"
-			}
-			return "no"
-		}
-
-		latencyTags = append(latencyTags, tag.Insert(metrics.FoundCaskade, yesno(foundCaskade)))
-		latencyTags = append(latencyTags, tag.Insert(metrics.FoundRegular, yesno(foundRegular)))
 	}
+
+	latencyTags = append(latencyTags, tag.Insert(metrics.Found, "yes"))
+	yesno := func(yn bool) string {
+		if yn {
+			return "yes"
+		}
+		return "no"
+	}
+
+	latencyTags = append(latencyTags, tag.Insert(metrics.FoundCaskade, yesno(foundCaskade)))
+	latencyTags = append(latencyTags, tag.Insert(metrics.FoundRegular, yesno(foundRegular)))
 
 	rs.observeFindResponse(&resp)
 	rs.reportMetrics(source)

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -343,7 +343,6 @@ LOOP:
 		stats.WithMeasurements(metrics.FindBackends.M(float64(atomic.LoadInt32(&count)))))
 
 	if len(results) == 0 {
-		log.Infow("X404 results not found for nd-json", "url", reqURL.String())
 		latencyTags = append(latencyTags, tag.Insert(metrics.Found, "no"))
 		http.Error(w, "", http.StatusNotFound)
 		return

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -134,7 +134,7 @@ func (rs *resultStats) reportMetrics(method string) {
 	}
 }
 
-func (s *server) doFindNDJson(ctx context.Context, w http.ResponseWriter, source string, req *url.URL, translateNonStreaming bool, mh multihash.Multihash, encrypted bool) {
+func (s *server) doFindNDJson(ctx context.Context, w http.ResponseWriter, source string, reqURL *url.URL, translateNonStreaming bool, mh multihash.Multihash, encrypted bool) {
 	start := time.Now()
 	latencyTags := []tag.Mutator{tag.Insert(metrics.Method, http.MethodGet)}
 	loadTags := []tag.Mutator{tag.Insert(metrics.Method, source)}
@@ -179,7 +179,7 @@ func (s *server) doFindNDJson(ctx context.Context, w http.ResponseWriter, source
 
 		// Copy the URL from original request and override host/schema to point
 		// to the server.
-		endpoint := *req
+		endpoint := *reqURL
 		endpoint.Host = b.URL().Host
 		endpoint.Scheme = b.URL().Scheme
 		log := log.With("backend", endpoint.Host)
@@ -343,6 +343,7 @@ LOOP:
 		stats.WithMeasurements(metrics.FindBackends.M(float64(atomic.LoadInt32(&count)))))
 
 	if len(results) == 0 {
+		log.Infow("X404 results not found for nd-json", "url", reqURL.String())
 		latencyTags = append(latencyTags, tag.Insert(metrics.Found, "no"))
 		http.Error(w, "", http.StatusNotFound)
 		return

--- a/providers.go
+++ b/providers.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"path"
 
-	//"github.com/ipni/go-libipni/find/model"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
@@ -48,6 +47,7 @@ func (s *server) provider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if pinfo == nil {
+		log.Infow("X404 provider not found", "id", pid)
 		http.Error(w, "", http.StatusNotFound)
 		return
 	}

--- a/providers.go
+++ b/providers.go
@@ -47,7 +47,6 @@ func (s *server) provider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if pinfo == nil {
-		log.Infow("X404 provider not found", "id", pid)
 		http.Error(w, "", http.StatusNotFound)
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -267,7 +267,6 @@ func (s *server) Serve() chan error {
 			}
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		default:
-			log.Infow("X404 url path not found", "path", r.URL.Path)
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		}
 	})

--- a/server.go
+++ b/server.go
@@ -267,6 +267,7 @@ func (s *server) Serve() chan error {
 			}
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		default:
+			log.Infow("X404 url path not found", "path", r.URL.Path)
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		}
 	})

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.1"
+  "version": "v0.1.2"
 }


### PR DESCRIPTION
The delegated find path in `delegated_translator.go` was being was being formed incorrectly, and did not remove the "providers/" part of the path.

The fix was to change this:
```go
uri := r.URL.JoinPath("../cid", cidUrlParam)
```
to this:
```go
uri := r.URL.JoinPath("../../cid", cidUrlParam)
```