### PR TITLE
Find can handle hex formatted multihashes

### DIFF
--- a/find.go
+++ b/find.go
@@ -54,8 +54,13 @@ func (s *server) findMultihashSubtree(w http.ResponseWriter, r *http.Request, en
 		smh := path.Base(r.URL.Path)
 		mh, err := multihash.FromB58String(smh)
 		if err != nil {
-			http.Error(w, "invalid multihash: "+err.Error(), http.StatusBadRequest)
-			return
+			if errors.Is(err, multihash.ErrInvalidMultihash) {
+				mh, err = multihash.FromHexString(smh)
+			}
+			if err != nil {
+				http.Error(w, "invalid multihash: "+err.Error(), http.StatusBadRequest)
+				return
+			}
 		}
 		s.find(w, r, mh, encrypted)
 	default:


### PR DESCRIPTION
Allows hex formatted multihashes to be used with the `/multihash/` and `/encrypted/multihash/` endpoints.

See also:
- https://github.com/ipni/specs/pull/31
- https://github.com/ipni/go-libipni/pull/209
