### PR TITLE
Add ndjson semantics to delegated routing endpoint

### DIFF
--- a/server.go
+++ b/server.go
@@ -246,7 +246,7 @@ func (s *server) Serve() chan error {
 	mux.HandleFunc("/health", s.health)
 
 	ec := make(chan error)
-	delegated, err := NewDelegatedTranslator(s.doFind)
+	delegated, err := NewDelegatedTranslator(s.doFind, s.doFindStreaming)
 	if err != nil {
 		ec <- err
 		close(ec)


### PR DESCRIPTION
Can maybe simplify code a bit as the delegated routing endpoint won't work with the encrypted results, so some of the complexity built for that isn't needed in this path.

Could add complexity to block on the `doFindStreaming` until the first result so that it can properly return a 404 in cases where there are are no results.