### PR TITLE
Add basic metrics for provider contribution to the result

### DIFF
--- a/find.go
+++ b/find.go
@@ -414,7 +414,7 @@ outer:
 	}
 
 	rs.observeFindResponse(&resp)
-	rs.reportMetrics(source)
+	rs.reportMetrics(source, s.detailedProvidersMetrics)
 
 	// write out combined.
 	outData, err := model.MarshalFindResponse(&resp)

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -38,6 +38,8 @@ type (
 	}
 )
 
+const detailedProvidersMetricsCardinalitySafetyLimit = 500
+
 func (r resultSet) putIfAbsent(p *encryptedOrPlainResult) bool {
 	// Calculate crc32 hash from provider ID + context ID to check for uniqueness of returned
 	// results. The rationale for using crc32 hashing is that it is fast and good enough
@@ -114,7 +116,7 @@ func (rs *resultStats) observeFindResponse(resp *model.FindResponse) {
 	}
 }
 
-func (rs *resultStats) reportMetrics(method string) {
+func (rs *resultStats) reportMetrics(method string, detailedProvidersMetrics bool) {
 	if rs.bitswapTransportCount > 0 {
 		metrics.FindResponse.
 			WithLabelValues(method, multicodec.TransportBitswap.String()).
@@ -137,6 +139,20 @@ func (rs *resultStats) reportMetrics(method string) {
 		metrics.FindResponse.
 			WithLabelValues(method, "encrypted").
 			Add(float64(rs.encCount))
+	}
+
+	if detailedProvidersMetrics {
+		rs.reportDetailedProvidersMetrics(method)
+	}
+}
+
+func (rs *resultStats) reportDetailedProvidersMetrics(method string) {
+	if len(rs.entriesByProvider) >= detailedProvidersMetricsCardinalitySafetyLimit {
+		// Stop emitting detailed providers metrics to avoid high cardinality.
+		metrics.FindProviderResults.DeletePartialMatch(nil)
+		metrics.FindProviderResultEntries.DeletePartialMatch(nil)
+		metrics.FindProviderResultWeighted.DeletePartialMatch(nil)
+		return
 	}
 
 	var totalEntries int64
@@ -413,7 +429,7 @@ func (s *server) doFindNDJson(
 
 	defer func() {
 		if found {
-			rs.reportMetrics(method)
+			rs.reportMetrics(method, s.detailedProvidersMetrics)
 		}
 
 		metrics.ReportFindLatency(method, found, foundCaskade, foundRegular, time.Since(start))
@@ -512,7 +528,7 @@ func (s *server) doFindStreaming(ctx context.Context, method string, reqURL *url
 			close(out)
 
 			if found {
-				rs.reportMetrics(method)
+				rs.reportMetrics(method, s.detailedProvidersMetrics)
 			}
 
 			metrics.ReportFindLatency(method, found, foundCaskade, foundRegular, time.Since(start))

--- a/find_ndjson.go
+++ b/find_ndjson.go
@@ -34,6 +34,7 @@ type (
 		bitswapTransportCount   int64
 		graphsyncTransportCount int64
 		unknwonTransportCount   int64
+		entriesByProvider       map[string]int64
 	}
 )
 
@@ -73,6 +74,11 @@ func (rs *resultStats) observeResult(result *encryptedOrPlainResult) {
 }
 
 func (rs *resultStats) observeProviderResult(result *model.ProviderResult) {
+	if rs.entriesByProvider == nil {
+		rs.entriesByProvider = make(map[string]int64)
+	}
+	rs.entriesByProvider[result.Provider.ID.String()]++
+
 	md := metadata.Default.New()
 	if err := md.UnmarshalBinary(result.Metadata); err != nil {
 		// TODO Refactor once there is concrete error type in index-provider
@@ -131,6 +137,25 @@ func (rs *resultStats) reportMetrics(method string) {
 		metrics.FindResponse.
 			WithLabelValues(method, "encrypted").
 			Add(float64(rs.encCount))
+	}
+
+	var totalEntries int64
+	for provider, count := range rs.entriesByProvider {
+		metrics.FindProviderResults.
+			WithLabelValues(provider, method).
+			Add(1)
+
+		metrics.FindProviderResultEntries.
+			WithLabelValues(provider, method).
+			Add(float64(count))
+
+		totalEntries += count
+	}
+
+	for provider, count := range rs.entriesByProvider {
+		metrics.FindProviderResultWeighted.
+			WithLabelValues(provider, method).
+			Add(float64(count) / float64(totalEntries))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -46,17 +46,17 @@ func runApp(
 		Usage: "indexstar is a point in the content routing galaxy - routes requests in a star topology",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:      "config",
+				Name:      configArg,
 				Usage:     "Path to config file",
 				TakesFile: true,
 			},
 			&cli.StringFlag{
-				Name:  "listen",
+				Name:  listenArg,
 				Usage: "HTTP server Listen address",
 				Value: ":8080",
 			},
 			&cli.StringFlag{
-				Name:  "metrics",
+				Name:  metricsArg,
 				Usage: "Metrics server listen address",
 				Value: ":8081",
 			},
@@ -78,11 +78,11 @@ func runApp(
 				Usage: "Backends to propagate providers requests to.",
 			},
 			&cli.BoolFlag{
-				Name:  "translateNonStreaming",
+				Name:  translateNonStreamingArg,
 				Usage: "Whether to translate non-streaming JSON requests to streaming NDJSON requests before scattering to backends.",
 			},
 			&cli.StringFlag{
-				Name:  "homepageURL",
+				Name:  homepageURLArg,
 				Usage: "The actual webUI backend to be rendered via iframe.",
 				Value: "https://web-ipni.cid.contact/",
 			},

--- a/main.go
+++ b/main.go
@@ -81,6 +81,11 @@ func runApp(
 				Name:  translateNonStreamingArg,
 				Usage: "Whether to translate non-streaming JSON requests to streaming NDJSON requests before scattering to backends.",
 			},
+			&cli.BoolFlag{
+				Name:   detailedProvidersMetricsArg,
+				Usage:  "Whether to report detailed stats for providers through metrics.",
+				Hidden: true,
+			},
 			&cli.StringFlag{
 				Name:  homepageURLArg,
 				Usage: "The actual webUI backend to be rendered via iframe.",

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -114,6 +114,28 @@ var (
 		},
 		[]string{LabelMethod},
 	)
+
+	FindProviderResults = promAuto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "indexstar_find_provider_results",
+			Help: "Number of results including a given provider",
+		},
+		[]string{LabelProvider, LabelMethod},
+	)
+	FindProviderResultWeighted = promAuto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "indexstar_find_provider_result_weighted",
+			Help: "Results per provider, weighted by their share of addresses in results",
+		},
+		[]string{LabelProvider, LabelMethod},
+	)
+	FindProviderResultEntries = promAuto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "indexstar_find_provider_result_entries",
+			Help: "Number of entries per provider returned total",
+		},
+		[]string{LabelProvider, LabelMethod},
+	)
 )
 
 func init() {

--- a/server.go
+++ b/server.go
@@ -26,15 +26,16 @@ var (
 )
 
 const (
-	configArg                = "config"
-	listenArg                = "listen"
-	metricsArg               = "metrics"
-	backendsArg              = "backends"
-	cascadeBackendsArg       = "cascadeBackends"
-	dhBackendsArg            = "dhBackends"
-	providersBackendsArg     = "providersBackends"
-	translateNonStreamingArg = "translateNonStreaming"
-	homepageURLArg           = "homepageURL"
+	configArg                   = "config"
+	listenArg                   = "listen"
+	metricsArg                  = "metrics"
+	backendsArg                 = "backends"
+	cascadeBackendsArg          = "cascadeBackends"
+	dhBackendsArg               = "dhBackends"
+	providersBackendsArg        = "providersBackends"
+	translateNonStreamingArg    = "translateNonStreaming"
+	detailedProvidersMetricsArg = "detailedProvidersMetrics"
+	homepageURLArg              = "homepageURL"
 )
 
 type serverInterface interface {
@@ -56,6 +57,8 @@ type server struct {
 	indexPageCompileTime time.Time
 	pcache               *pcache.ProviderCache
 	pcounts              *ProviderMap
+
+	detailedProvidersMetrics bool
 }
 
 // caskadeBackend is a marker for caskade backends
@@ -168,17 +171,18 @@ func NewServer(c *cli.Context) (serverInterface, error) {
 	compileTime := time.Now()
 
 	s := server{
-		Context:               c.Context,
-		Client:                httpClient,
-		cfgBase:               c.String(configArg),
-		Listener:              bound,
-		metricsListener:       mb,
-		backends:              backends,
-		translateNonStreaming: c.Bool(translateNonStreamingArg),
-		indexPage:             indexPageBuf.Bytes(),
-		indexPageCompileTime:  compileTime,
-		pcache:                pc,
-		pcounts:               pCounts,
+		Context:                  c.Context,
+		Client:                   httpClient,
+		cfgBase:                  c.String(configArg),
+		Listener:                 bound,
+		metricsListener:          mb,
+		backends:                 backends,
+		translateNonStreaming:    c.Bool(translateNonStreamingArg),
+		indexPage:                indexPageBuf.Bytes(),
+		indexPageCompileTime:     compileTime,
+		pcache:                   pc,
+		pcounts:                  pCounts,
+		detailedProvidersMetrics: c.Bool(detailedProvidersMetricsArg),
 	}
 
 	// Listeners propagated to the server, don't close on defer

--- a/server.go
+++ b/server.go
@@ -26,10 +26,15 @@ var (
 )
 
 const (
-	backendsArg          = "backends"
-	cascadeBackendsArg   = "cascadeBackends"
-	dhBackendsArg        = "dhBackends"
-	providersBackendsArg = "providersBackends"
+	configArg                = "config"
+	listenArg                = "listen"
+	metricsArg               = "metrics"
+	backendsArg              = "backends"
+	cascadeBackendsArg       = "cascadeBackends"
+	dhBackendsArg            = "dhBackends"
+	providersBackendsArg     = "providersBackends"
+	translateNonStreamingArg = "translateNonStreaming"
+	homepageURLArg           = "homepageURL"
 )
 
 type serverInterface interface {
@@ -69,7 +74,7 @@ type providersBackend struct {
 func NewServer(c *cli.Context) (serverInterface, error) {
 	var lc net.ListenConfig
 
-	bound, err := lc.Listen(c.Context, "tcp", c.String("listen"))
+	bound, err := lc.Listen(c.Context, "tcp", c.String(listenArg))
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +84,7 @@ func NewServer(c *cli.Context) (serverInterface, error) {
 		}
 	}()
 
-	mb, err := lc.Listen(c.Context, "tcp", c.String("metrics"))
+	mb, err := lc.Listen(c.Context, "tcp", c.String(metricsArg))
 	if err != nil {
 		return nil, err
 	}
@@ -96,10 +101,10 @@ func NewServer(c *cli.Context) (serverInterface, error) {
 	pCounts := NewProviderMap(config.Server.TopProviderCardinality)
 
 	if len(servers) == 0 {
-		if !c.IsSet("config") {
+		if !c.IsSet(configArg) {
 			return nil, fmt.Errorf("no backends specified")
 		}
-		servers, err = Load(c.String("config"))
+		servers, err = Load(c.String(configArg))
 		if err != nil {
 			return nil, fmt.Errorf("could not load backends from config: %w", err)
 		}
@@ -156,7 +161,7 @@ func NewServer(c *cli.Context) (serverInterface, error) {
 	if err = indexTemplate.Execute(&indexPageBuf, struct {
 		URL string
 	}{
-		URL: c.String("homepageURL"),
+		URL: c.String(homepageURLArg),
 	}); err != nil {
 		return nil, err
 	}
@@ -165,11 +170,11 @@ func NewServer(c *cli.Context) (serverInterface, error) {
 	s := server{
 		Context:               c.Context,
 		Client:                httpClient,
-		cfgBase:               c.String("config"),
+		cfgBase:               c.String(configArg),
 		Listener:              bound,
 		metricsListener:       mb,
 		backends:              backends,
-		translateNonStreaming: c.Bool("translateNonStreaming"),
+		translateNonStreaming: c.Bool(translateNonStreamingArg),
 		indexPage:             indexPageBuf.Bytes(),
 		indexPageCompileTime:  compileTime,
 		pcache:                pc,


### PR DESCRIPTION
* indexstar_find_provider_results - counter increased for every result containing at least one entry for a given provider
* indexstar_find_provider_result_weighted - contribution of providers to the final results, weighted by their share of addresses in results
* indexstar_find_provider_result_entries - contribution of providers to the final result in total number of addresses returned for a given provider

At this moment we do not limit cardinality of those metrics as this is just a precursor of more advanced provider metering. With the current set of providers (~150) there's no risk of data explosion yet.