### PR TITLE
Don't panic on gathering top providers metrics

### DIFF
--- a/find.go
+++ b/find.go
@@ -383,7 +383,7 @@ outer:
 					}
 					updateFoundFlags(r.bknd)
 					resp.MultihashResults[0].ProviderResults = append(resp.MultihashResults[0].ProviderResults, pr)
-					s.pcounts.Add(string(pr.Provider.ID))
+					s.pcounts.Add(pr.Provider.ID)
 				}
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/multiformats/go-multicodec v0.10.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/net v0.54.0
@@ -38,7 +39,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.90.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.68.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/pcountmap.go
+++ b/pcountmap.go
@@ -23,13 +23,11 @@ func NewProviderMap(cardinality int) *ProviderMap {
 
 func (pm *ProviderMap) Add(provider peer.ID) {
 	pm.lock.RLock()
-	defer pm.lock.RUnlock()
-	var c *atomic.Int64
-	var exists bool
+	c, exists := pm.providers[provider]
+	pm.lock.RUnlock()
 
-	if c, exists = pm.providers[provider]; !exists {
+	if !exists {
 		// slow case..
-		pm.lock.RUnlock()
 		pm.lock.Lock()
 		if c, exists = pm.providers[provider]; !exists { // Double-check
 			newP := atomic.Int64{}
@@ -37,7 +35,6 @@ func (pm *ProviderMap) Add(provider peer.ID) {
 			c = &newP
 		}
 		pm.lock.Unlock()
-		pm.lock.RLock()
 	}
 
 	c.Add(1)
@@ -49,7 +46,19 @@ type ProviderCount struct {
 }
 
 func (pm *ProviderMap) Top() []ProviderCount {
-	n := pm.cardinality
+	pairs := pm.gatherProviderCounts()
+
+	// Sort pairs by count in descending order
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].Count > pairs[j].Count
+	})
+
+	n := min(pm.cardinality, len(pairs))
+
+	return pairs[0:n]
+}
+
+func (pm *ProviderMap) gatherProviderCounts() []ProviderCount {
 	pm.lock.RLock()
 	defer pm.lock.RUnlock()
 
@@ -58,14 +67,5 @@ func (pm *ProviderMap) Top() []ProviderCount {
 		pairs = append(pairs, ProviderCount{Provider: provider, Count: count.Load()})
 	}
 
-	// Sort pairs by count in descending order
-	sort.Slice(pairs, func(i, j int) bool {
-		return pairs[i].Count > pairs[j].Count
-	})
-
-	if n > len(pairs) {
-		n = len(pairs)
-	}
-
-	return pairs[0:n]
+	return pairs
 }

--- a/pcountmap.go
+++ b/pcountmap.go
@@ -4,22 +4,24 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 type ProviderMap struct {
 	cardinality int
-	providers   map[string]*atomic.Int64
+	providers   map[peer.ID]*atomic.Int64
 	lock        sync.RWMutex
 }
 
 func NewProviderMap(cardinality int) *ProviderMap {
 	return &ProviderMap{
 		cardinality: cardinality,
-		providers:   make(map[string]*atomic.Int64),
+		providers:   make(map[peer.ID]*atomic.Int64),
 	}
 }
 
-func (pm *ProviderMap) Add(provider string) {
+func (pm *ProviderMap) Add(provider peer.ID) {
 	pm.lock.RLock()
 	defer pm.lock.RUnlock()
 	var c *atomic.Int64
@@ -42,7 +44,7 @@ func (pm *ProviderMap) Add(provider string) {
 }
 
 type ProviderCount struct {
-	Provider string
+	Provider peer.ID
 	Count    int64
 }
 

--- a/pcountmap_test.go
+++ b/pcountmap_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"testing/synctest"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderMapConcurrentAddSameProvider(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			goroutines       = 64
+			addsPerGoroutine = 250
+		)
+
+		pm := NewProviderMap(1)
+		provider := randomPeerID(t)
+
+		var wg sync.WaitGroup
+		for range goroutines {
+			wg.Go(func() {
+				for range addsPerGoroutine {
+					pm.Add(provider)
+				}
+			})
+		}
+
+		wg.Wait()
+		synctest.Wait()
+
+		top := pm.Top()
+		require.Len(t, top, 1)
+		require.Equal(t, provider, top[0].Provider)
+		require.Equal(t, int64(goroutines*addsPerGoroutine), top[0].Count)
+	})
+}
+
+func TestProviderMapConcurrentAddDistinctProviders(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			providerCount    = 64
+			goroutines       = 64
+			addsPerGoroutine = 100
+		)
+
+		pm := NewProviderMap(providerCount)
+		providers := make([]peer.ID, providerCount)
+		for i := range providers {
+			providers[i] = randomPeerID(t)
+		}
+
+		var wg sync.WaitGroup
+		for g := range goroutines {
+			provider := providers[g]
+			wg.Go(func() {
+				for range addsPerGoroutine {
+					pm.Add(provider)
+				}
+			})
+		}
+
+		wg.Wait()
+		synctest.Wait()
+
+		counts := providerCountMap(pm, providerCount)
+		require.Len(t, counts, providerCount)
+
+		for i, provider := range providers {
+			require.Equal(t, int64(addsPerGoroutine), counts[provider], "provider %d", i)
+		}
+	})
+}
+
+func TestProviderMapConcurrentAddOverlappingProviders(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			providerCount    = 32
+			goroutines       = 96
+			addsPerGoroutine = 200
+		)
+
+		pm := NewProviderMap(providerCount)
+		providers := make([]peer.ID, providerCount)
+		for i := range providers {
+			providers[i] = randomPeerID(t)
+		}
+
+		var wg sync.WaitGroup
+		for g := range goroutines {
+			wg.Go(func() {
+				for j := range addsPerGoroutine {
+					pm.Add(providers[(g+j)%providerCount])
+				}
+			})
+		}
+
+		wg.Wait()
+		synctest.Wait()
+
+		counts := providerCountMap(pm, providerCount)
+		require.Len(t, counts, providerCount)
+
+		var total int64
+		for _, count := range counts {
+			total += count
+		}
+		require.Equal(t, int64(goroutines*addsPerGoroutine), total)
+	})
+}
+
+func providerCountMap(pm *ProviderMap, cardinality int) map[peer.ID]int64 {
+	orig := pm.cardinality
+	pm.cardinality = cardinality
+	defer func() { pm.cardinality = orig }()
+
+	counts := make(map[peer.ID]int64, cardinality)
+	for _, rcrd := range pm.Top() {
+		counts[rcrd.Provider] = rcrd.Count
+	}
+	return counts
+}
+
+func TestProviderMapConcurrentStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			providerCount = 64
+			goroutines    = 128
+			operations    = 2000
+		)
+
+		pm := NewProviderMap(10)
+		providers := make([]peer.ID, providerCount)
+		for i := range providers {
+			providers[i] = peer.ID(fmt.Appendf(nil, "provider-%d-%s", i, randomPeerID(t)))
+		}
+
+		var wg sync.WaitGroup
+		for g := range goroutines {
+			wg.Go(func() {
+				for op := range operations {
+					switch op % 3 {
+					case 0, 1:
+						pm.Add(providers[(g+op)%providerCount])
+					case 2:
+						_ = pm.Top()
+					}
+				}
+			})
+		}
+
+		wg.Wait()
+		synctest.Wait()
+
+		counts := providerCountMap(pm, providerCount)
+		require.NotEmpty(t, counts)
+
+		top := pm.Top()
+		require.Len(t, top, 10)
+		for i := 1; i < len(top); i++ {
+			require.GreaterOrEqual(t, top[i-1].Count, top[i].Count)
+		}
+	})
+}

--- a/server.go
+++ b/server.go
@@ -296,7 +296,9 @@ func (s *server) updateTopProviders() {
 	metrics.TopProvider.DeletePartialMatch(nil)
 
 	for _, rcrd := range top {
-		metrics.TopProvider.WithLabelValues(rcrd.Provider).Set(float64(rcrd.Count))
+		metrics.TopProvider.
+			WithLabelValues(rcrd.Provider.String()).
+			Set(float64(rcrd.Count))
 	}
 }
 

--- a/server_metrics_test.go
+++ b/server_metrics_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ipni/indexstar/metrics"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateTopProvidersReportsTopOnlyAndPrunesStale(t *testing.T) {
+	srv := &server{
+		pcounts: NewProviderMap(2),
+	}
+
+	invalidUTF8PeerID := peer.ID(string([]byte{0xff, 0xfe, 0xfd}))
+	providerA := randomPeerID(t)
+	providerB := randomPeerID(t)
+	providerC := randomPeerID(t)
+
+	addProviderCount := func(provider peer.ID, count int) {
+		for range count {
+			srv.pcounts.Add(provider)
+		}
+	}
+
+	// First snapshot: only the top 2 providers should be emitted.
+	addProviderCount(providerA, 10)
+	addProviderCount(invalidUTF8PeerID, 9)
+	addProviderCount(providerB, 8)
+	addProviderCount(providerC, 1)
+
+	srv.updateTopProviders()
+
+	got := readTopProviderMetrics(t)
+	require.Len(t, got, 2)
+	require.Equal(t, 10.0, got[providerA.String()])
+	require.Equal(t, 9.0, got[invalidUTF8PeerID.String()])
+	require.NotContains(t, got, providerB.String())
+	require.NotContains(t, got, providerC.String())
+
+	// Second snapshot: old top providers should be removed when top list changes.
+	addProviderCount(providerB, 20)
+	addProviderCount(providerC, 30)
+
+	srv.updateTopProviders()
+
+	got = readTopProviderMetrics(t)
+	require.Len(t, got, 2)
+	require.Equal(t, 31.0, got[providerC.String()])
+	require.Equal(t, 28.0, got[providerB.String()])
+	require.NotContains(t, got, providerA.String())
+	require.NotContains(t, got, invalidUTF8PeerID.String())
+}
+
+func readTopProviderMetrics(t *testing.T) map[string]float64 {
+	t.Helper()
+
+	ch := make(chan prometheus.Metric, 256)
+	metrics.TopProvider.Collect(ch)
+	close(ch)
+
+	values := make(map[string]float64)
+	for metric := range ch {
+		pb := &dto.Metric{}
+		require.NoError(t, metric.Write(pb))
+		require.NotNil(t, pb.Gauge)
+
+		var providerLabel string
+		for _, label := range pb.Label {
+			if label.GetName() == metrics.LabelProvider {
+				providerLabel = label.GetValue()
+				break
+			}
+		}
+		require.NotEmpty(t, providerLabel)
+		values[providerLabel] = pb.Gauge.GetValue()
+	}
+
+	return values
+}


### PR DESCRIPTION
Use .String() method of provider.ID entry instead of using string(id) cast as the id may not be a valid UTF-8 sequence that causes panics when emitting metrics with such label.